### PR TITLE
Check if disk space functions exist before calling them

### DIFF
--- a/core/components/sitedashclient/src/Refresh.php
+++ b/core/components/sitedashclient/src/Refresh.php
@@ -87,8 +87,8 @@ class Refresh implements CommandInterface {
             $data['database_server_info'] = $pdoInstance->getAttribute(\PDO::ATTR_SERVER_INFO);
         }
 
-        $data['disk_free_space'] = @disk_free_space(MODX_BASE_PATH);
-        $data['disk_total_space'] = @disk_total_space(MODX_BASE_PATH);
+        $data['disk_free_space'] = function_exists('disk_free_space') ? disk_free_space(MODX_BASE_PATH) : false;
+        $data['disk_total_space'] = function_exists('disk_total_space') ? disk_total_space(MODX_BASE_PATH) : false;
         $data['memory_limit'] = ini_get('memory_limit');
         $data['max_execution_time'] = ini_get('max_execution_time');
         $data['session_gc_probability'] = (int)ini_get('session.gc_probability');

--- a/core/components/sitedashclient/src/Refresh.php
+++ b/core/components/sitedashclient/src/Refresh.php
@@ -87,8 +87,8 @@ class Refresh implements CommandInterface {
             $data['database_server_info'] = $pdoInstance->getAttribute(\PDO::ATTR_SERVER_INFO);
         }
 
-        $data['disk_free_space'] = function_exists('disk_free_space') ? disk_free_space(MODX_BASE_PATH) : false;
-        $data['disk_total_space'] = function_exists('disk_total_space') ? disk_total_space(MODX_BASE_PATH) : false;
+        $data['disk_free_space'] = function_exists('disk_free_space') ? @disk_free_space(MODX_BASE_PATH) : false;
+        $data['disk_total_space'] = function_exists('disk_total_space') ? @disk_total_space(MODX_BASE_PATH) : false;
         $data['memory_limit'] = ini_get('memory_limit');
         $data['max_execution_time'] = ini_get('max_execution_time');
         $data['session_gc_probability'] = (int)ini_get('session.gc_probability');


### PR DESCRIPTION
With PHP8 `@` operator no longer silences fatal errors.
On systems with blocked `disk_total_space` or `disk_free_space` this causes an error 500.
The default value is now `false`. That's the same the two functions return on error.

https://www.php.net/manual/en/language.operators.errorcontrol.php
https://www.php.net/manual/en/function.disk-total-space.php